### PR TITLE
[EZ] Replace `pytorch-labs` with `meta-pytorch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Step 2
 Install the package
 
 ```
-pip install git+https://github.com/pytorch-labs/segment-anything-fast.git
+pip install git+https://github.com/meta-pytorch/segment-anything-fast.git
 ```
 
 ## Usage
@@ -73,4 +73,4 @@ That means the very last bar is the combination of
 
 ## License
 
-`segment-anything-fast` is released under the [Apache 2.0](https://github.com/pytorch-labs/segment-anything-fast/main/LICENSE) license.
+`segment-anything-fast` is released under the [Apache 2.0](https://github.com/meta-pytorch/segment-anything-fast/main/LICENSE) license.

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -43,7 +43,7 @@ Meanwhile, these experiments (fp32, bf16, compile, SDPA, Triton, NT) can run on 
 
 - PyTorch nightly and Python 3.10
 - https://github.com/cpuhrsch/segment-anything fork of https://github.com/facebookresearch/segment-anything with additional commits if you want to reproduce baseline and first few experiments
-- This https://github.com/pytorch-labs/segment-anything-fast
+- This https://github.com/meta-pytorch/segment-anything-fast
 
 ### Installation instructions
 
@@ -63,7 +63,7 @@ $ git clone https://github.com/cpuhrsch/segment-anything.git
 $ cd segment-anything
 $ pip install -e .
 $ cd ..
-$ git clone https://github.com/pytorch-labs/segment-anything-fast.git
+$ git clone https://github.com/meta-pytorch/segment-anything-fast.git
 $ cd segment-anything-fast
 $ pip install -e .
 ```
@@ -92,11 +92,11 @@ Measurement
 Accuracy
 Our main goal is to verify that our performance optimizations do not degrade the accuracy of the model. We do not aim to reproduce any paper results or aim to make statements about the accuracy of this model on the dataset. This measurement serves as an additional integration test in conjunction with numerous unit and other separate integration tests.
 
-We calculate the center points of the mask annotations using a rudimentary version of https://arxiv.org/pdf/2304.02643.pdf, section D.1.Point Sampling ([code](https://github.com/pytorch-labs/segment-anything-fast/blob/67d5c894569e99b9fdba55cfcf2f724be9f68994/experiments/data.py#L10-L120)). These center points serve as annotations per image. Note that the number of masks and thus number of annotations per image vary.
+We calculate the center points of the mask annotations using a rudimentary version of https://arxiv.org/pdf/2304.02643.pdf, section D.1.Point Sampling ([code](https://github.com/meta-pytorch/segment-anything-fast/blob/67d5c894569e99b9fdba55cfcf2f724be9f68994/experiments/data.py#L10-L120)). These center points serve as annotations per image. Note that the number of masks and thus number of annotations per image vary.
 
-These images and annotations are given to the predict_torch method of an instance of SamPredictor to predict masks. These are then compared to the ground truth masks using the Intersection over Union (IoU) metric ([code](https://github.com/pytorch-labs/segment-anything-fast/blob/67d5c894569e99b9fdba55cfcf2f724be9f68994/experiments/metrics.py#L4-L22)). We calculate the mean IoU (mIoU) metric over the entire 5000 images of the validation dataset to track accuracy.
+These images and annotations are given to the predict_torch method of an instance of SamPredictor to predict masks. These are then compared to the ground truth masks using the Intersection over Union (IoU) metric ([code](https://github.com/meta-pytorch/segment-anything-fast/blob/67d5c894569e99b9fdba55cfcf2f724be9f68994/experiments/metrics.py#L4-L22)). We calculate the mean IoU (mIoU) metric over the entire 5000 images of the validation dataset to track accuracy.
 Performance
-Our goal is to measure the runtime of PyTorch models. We purposefully exclude data movements or calculation of the metrics. Specifically we measure the execution time on the GPU of running the image encoder (e.g. vit_h) and SamPredictor.predict_torch ([code](https://github.com/pytorch-labs/segment-anything-fast/blob/67d5c894569e99b9fdba55cfcf2f724be9f68994/experiments/eval_combo.py#L127-L165), [code](https://github.com/pytorch-labs/segment-anything-fast/blob/67d5c894569e99b9fdba55cfcf2f724be9f68994/experiments/eval_combo.py#L68-L99)).
+Our goal is to measure the runtime of PyTorch models. We purposefully exclude data movements or calculation of the metrics. Specifically we measure the execution time on the GPU of running the image encoder (e.g. vit_h) and SamPredictor.predict_torch ([code](https://github.com/meta-pytorch/segment-anything-fast/blob/67d5c894569e99b9fdba55cfcf2f724be9f68994/experiments/eval_combo.py#L127-L165), [code](https://github.com/meta-pytorch/segment-anything-fast/blob/67d5c894569e99b9fdba55cfcf2f724be9f68994/experiments/eval_combo.py#L68-L99)).
 
 Each experiment is run in a separate Python process created from scratch. We run three batches of warmup before each experiment. This also implies that we are excluding compilation time from benchmarking. 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 packages = find_packages()
 print("packages: ", packages)
 setup(
-    name='pytorch-labs-segment-anything-fast',
+    name='meta-pytorch-segment-anything-fast',
     version='0.2',
     packages=packages,
     install_requires=[
@@ -21,7 +21,7 @@ setup(
     },
     description='A pruned, quantized, compiled, nested and batched implementation of segment-anything',
     long_description_content_type='text/markdown',
-    url='https://github.com/pytorch-labs/segment-anything-fast',
+    url='https://github.com/meta-pytorch/segment-anything-fast',
     classifiers=[
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 packages = find_packages()
 print("packages: ", packages)
 setup(
-    name='meta-pytorch-segment-anything-fast',
+    name='pytorch-labs-segment-anything-fast',
     version='0.2',
     packages=packages,
     install_requires=[


### PR DESCRIPTION
This PR replaces all instances of `pytorch-labs` with `meta-pytorch` in this repository now that the `pytorch-labs` org has been renamed to `meta-pytorch`

## Changes Made
- Replaced all occurrences of `pytorch-labs` with `meta-pytorch`
- Skipped binary files and files larger than 1MB due to GitHub api payload limits in the script to cover all repos in this org. Will do a more manual second pass later to cover any larger files

## Files Modified
This PR updates files that contained the target text.

Generated by automated script on 2025-08-22T23:26:03.510251+00:00Z